### PR TITLE
Bump AZP VM to Ubuntu 24.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ schedules:
         - main
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-24.04'
 
 variables:
   ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
Ubuntu 20.04 will be gone on April 1st.

Ref: https://aka.ms/azdo-ubuntu-20.04